### PR TITLE
Fix splat

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Terraform module that provisions an SSH TLS key pair and writes it to SSM Parameter Store.
 
+This is useful for bot accounts (e.g. for GitHub). Easily rotate SSH secrets by simply tainting the module resource and reapplying.
+
 
 ---
 
@@ -68,7 +70,6 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -76,8 +77,8 @@ Available targets:
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | ecdsa_curve | When ssh_key_algorithm is 'ECDSA', the name of the elliptic curve to use. May be any one of 'P256', 'P384' or P521' | string | `P256` | no |
-| enable_kms_key_rotation | Whether KMS key rotation is enabled | string | `true` | no |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | string | `true` | no |
+| kms_key_id | KMS Key ID used for encryption | string | `` | no |
 | name | Application or solution name (e.g. `app`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | overwrite_ssm_parameter | Whether to overwrite an existing SSM parameter | string | `true` | no |
@@ -85,6 +86,7 @@ Available targets:
 | ssh_key_algorithm | SSH key algorithm to use. Currently-supported values are 'RSA' and 'ECDSA' | string | `RSA` | no |
 | ssh_private_key_name | SSM Parameter name of the SSH private key | string | `` | no |
 | ssh_public_key_name | SSM Parameter name of the SSH public key | string | `` | no |
+| ssm_path_format | SSM path format | string | `/%s/%s` | no |
 | ssm_path_prefix | The SSM parameter path prefix (e.g. /$ssm_path_prefix/$key_name) | string | `ssh_keys` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -40,6 +40,8 @@ related:
 description: |-
   Terraform module that provisions an SSH TLS key pair and writes it to SSM Parameter Store.
 
+  This is useful for bot accounts (e.g. for GitHub). Easily rotate SSH secrets by simply tainting the module resource and reapplying.
+
 # How to use this project
 usage: |-
   ```hcl

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,4 +1,3 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -6,8 +5,8 @@
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | ecdsa_curve | When ssh_key_algorithm is 'ECDSA', the name of the elliptic curve to use. May be any one of 'P256', 'P384' or P521' | string | `P256` | no |
-| enable_kms_key_rotation | Whether KMS key rotation is enabled | string | `true` | no |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | string | `true` | no |
+| kms_key_id | KMS Key ID used for encryption | string | `` | no |
 | name | Application or solution name (e.g. `app`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | overwrite_ssm_parameter | Whether to overwrite an existing SSM parameter | string | `true` | no |
@@ -15,6 +14,7 @@
 | ssh_key_algorithm | SSH key algorithm to use. Currently-supported values are 'RSA' and 'ECDSA' | string | `RSA` | no |
 | ssh_private_key_name | SSM Parameter name of the SSH private key | string | `` | no |
 | ssh_public_key_name | SSM Parameter name of the SSH public key | string | `` | no |
+| ssm_path_format | SSM path format | string | `/%s/%s` | no |
 | ssm_path_prefix | The SSM parameter path prefix (e.g. /$ssm_path_prefix/$key_name) | string | `ssh_keys` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |

--- a/main.tf
+++ b/main.tf
@@ -17,13 +17,14 @@ locals {
   default_private_key_name = "${local.remapped_label_id}_private_key"
   public_key_name          = "${length(var.ssh_public_key_name) > 0 ? var.ssh_public_key_name : local.default_public_key_name}"
   private_key_name         = "${length(var.ssh_private_key_name) > 0 ? var.ssh_private_key_name : local.default_private_key_name}"
-  ssh_public_key_ssm_path  = "${format("/%s/%s", var.ssm_path_prefix, local.public_key_name)}"
-  ssh_private_key_ssm_path = "${format("/%s/%s", var.ssm_path_prefix, local.private_key_name)}"
+  ssh_public_key_ssm_path  = "${format(var.ssm_path_format, var.ssm_path_prefix, local.public_key_name)}"
+  ssh_private_key_ssm_path = "${format(var.ssm_path_format, var.ssm_path_prefix, local.private_key_name)}"
+  kms_key_id               = "${length(var.kms_key_id) ? var.kms_key_id : format("alias/%s-%s-chamber", var.namespace, var.stage)}"
 }
 
-data "aws_kms_key" "chamber_kms_key" {
+data "aws_kms_key" "kms_key" {
   count  = "${local.enabled ? 1 : 0}"
-  key_id = "${format("alias/%s-%s-chamber", var.namespace, var.stage)}"
+  key_id = "${local.kms_key_id}"
 }
 
 resource "tls_private_key" "default_rsa" {
@@ -43,7 +44,7 @@ resource "aws_ssm_parameter" "private_rsa_key" {
   name        = "${local.ssh_private_key_ssm_path}"
   description = "TLS Private Key"
   type        = "SecureString"
-  key_id      = "${join("", data.aws_kms_key.chamber_kms_key.*.id)}"
+  key_id      = "${join("", data.aws_kms_key.kms_key.*.id)}"
   value       = "${join("", tls_private_key.default_rsa.*.private_key_pem)}"
   overwrite   = "${var.overwrite_ssm_parameter}"
   depends_on  = ["tls_private_key.default_rsa"]
@@ -66,7 +67,7 @@ resource "aws_ssm_parameter" "private_ecdsa_key" {
   name        = "${local.ssh_private_key_ssm_path}"
   description = "TLS Private Key (${var.ssh_key_algorithm})"
   type        = "SecureString"
-  key_id      = "${join("",data.aws_kms_key.chamber_kms_key.id)}"
+  key_id      = "${join("",data.aws_kms_key.kms_key.*.id)}"
   value       = "${join("", tls_private_key.default_ecdsa.*.private_key_pem)}"
   overwrite   = "${var.overwrite_ssm_parameter}"
   depends_on  = ["tls_private_key.default_ecdsa"]

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ locals {
   private_key_name         = "${length(var.ssh_private_key_name) > 0 ? var.ssh_private_key_name : local.default_private_key_name}"
   ssh_public_key_ssm_path  = "${format(var.ssm_path_format, var.ssm_path_prefix, local.public_key_name)}"
   ssh_private_key_ssm_path = "${format(var.ssm_path_format, var.ssm_path_prefix, local.private_key_name)}"
-  kms_key_id               = "${length(var.kms_key_id) ? var.kms_key_id : format("alias/%s-%s-chamber", var.namespace, var.stage)}"
+  kms_key_id               = "${length(var.kms_key_id) > 0 ? var.kms_key_id : format("alias/%s-%s-chamber", var.namespace, var.stage)}"
 }
 
 data "aws_kms_key" "kms_key" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,16 +42,17 @@ variable "overwrite_ssm_parameter" {
   default     = "true"
   description = "Whether to overwrite an existing SSM parameter"
 }
+
 variable "ssm_path_format" {
-  type = "string"
+  type        = "string"
   description = "SSM path format"
-  default = "/%s/%s"
+  default     = "/%s/%s"
 }
 
 variable "kms_key_id" {
-  type = "string"
+  type        = "string"
   description = "KMS Key ID used for encryption"
-  default = ""
+  default     = ""
 }
 
 variable "ssh_public_key_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,11 +42,16 @@ variable "overwrite_ssm_parameter" {
   default     = "true"
   description = "Whether to overwrite an existing SSM parameter"
 }
+variable "ssm_path_format" {
+  type = "string"
+  description = "SSM path format"
+  default = "/%s/%s"
+}
 
-variable "enable_kms_key_rotation" {
-  type        = "string"
-  default     = "true"
-  description = "Whether KMS key rotation is enabled"
+variable "kms_key_id" {
+  type = "string"
+  description = "KMS Key ID used for encryption"
+  default = ""
 }
 
 variable "ssh_public_key_name" {


### PR DESCRIPTION
## what
* Fix splat
* Remove unused var
* Parameterize constants
* Configurable KMS Key ID
* Add use-case

## why
* Splat required when using `count`
* the KMS key previously would only work with cloudposse-style resource IDs which is too strict  
* Closes #3 